### PR TITLE
Making the RecaptchaSettings.SecretKey property public

### DIFF
--- a/docs/Griesoft.AspNetCore.ReCaptcha.xml
+++ b/docs/Griesoft.AspNetCore.ReCaptcha.xml
@@ -77,21 +77,17 @@
             </remarks>
             <seealso cref="N:Microsoft.Extensions.Configuration"/>
         </member>
-        <member name="M:Griesoft.AspNetCore.ReCaptcha.Configuration.RecaptchaSettings.#ctor">
-            <summary>
-            
-            </summary>
-        </member>
-        <member name="M:Griesoft.AspNetCore.ReCaptcha.Configuration.RecaptchaSettings.#ctor(System.String,System.String)">
-            <summary>
-            
-            </summary>
-            <param name="siteKey"></param>
-            <param name="secretKey"></param>
-        </member>
         <member name="P:Griesoft.AspNetCore.ReCaptcha.Configuration.RecaptchaSettings.SiteKey">
             <summary>
-            The public reCAPTCHA site key. Will be added to reCAPTCHA HTML elements as the data-sitekey attribute.
+            The reCAPTCHA site key.
+            </summary>
+            <remarks>
+            Will be added to reCAPTCHA HTML elements as the data-sitekey attribute.
+            </remarks>
+        </member>
+        <member name="P:Griesoft.AspNetCore.ReCaptcha.Configuration.RecaptchaSettings.SecretKey">
+            <summary>
+            The reCAPTCHA secret key.
             </summary>
         </member>
         <member name="T:Griesoft.AspNetCore.ReCaptcha.TagHelpers.BadgePosition">

--- a/src/ReCaptcha/Configuration/RecaptchaSettings.cs
+++ b/src/ReCaptcha/Configuration/RecaptchaSettings.cs
@@ -10,27 +10,16 @@
     public class RecaptchaSettings
     {
         /// <summary>
-        /// 
+        /// The reCAPTCHA site key.
         /// </summary>
-        public RecaptchaSettings() { }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="siteKey"></param>
-        /// <param name="secretKey"></param>
-        public RecaptchaSettings(string siteKey, string secretKey)
-        {
-            SiteKey = siteKey;
-            SecretKey = secretKey;
-        }
-
-
-        /// <summary>
-        /// The public reCAPTCHA site key. Will be added to reCAPTCHA HTML elements as the data-sitekey attribute.
-        /// </summary>
+        /// <remarks>
+        /// Will be added to reCAPTCHA HTML elements as the data-sitekey attribute.
+        /// </remarks>
         public string SiteKey { get; set; } = string.Empty;
 
-        internal string SecretKey { get; set; } = string.Empty;
+        /// <summary>
+        /// The reCAPTCHA secret key.
+        /// </summary>
+        public string SecretKey { get; set; } = string.Empty;
     }
 }

--- a/src/ReCaptcha/Extensions/TagHelperOutputExtensions.cs
+++ b/src/ReCaptcha/Extensions/TagHelperOutputExtensions.cs
@@ -112,7 +112,7 @@ namespace Griesoft.AspNetCore.ReCaptcha.Extensions
 
         private static string ExtractClassValue(TagHelperAttribute classAttribute, HtmlEncoder htmlEncoder)
         {
-            string extractedClassValue;
+            string? extractedClassValue;
             switch (classAttribute.Value)
             {
                 case string valueAsString:
@@ -129,7 +129,7 @@ namespace Griesoft.AspNetCore.ReCaptcha.Extensions
                     }
                     break;
                 default:
-                    extractedClassValue = htmlEncoder.Encode(classAttribute.Value?.ToString());
+                    extractedClassValue = htmlEncoder.Encode(classAttribute.Value.ToString() ?? string.Empty);
                     break;
             }
             var currentClassValue = extractedClassValue ?? string.Empty;


### PR DESCRIPTION
Making the `RecaptchaSettings.SecretKey` property now also public with extensibility in mind.